### PR TITLE
Don't compare hotp with counter

### DIFF
--- a/lib/setaria.ex
+++ b/lib/setaria.ex
@@ -71,7 +71,7 @@ defmodule Setaria do
   @spec valid_hotp(token :: String.t, secret :: String.t, counter :: Integer.t, opts :: Keyword.t) :: boolean
   def valid_hotp(token, secret, counter, opts \\ []) do
     encoded_secret = get_encoded_secret(secret, opts)
-    :pot.valid_hotp(token, encoded_secret, [{:last, counter - 1}]) == counter
+    :pot.valid_hotp(token, encoded_secret, [{:last, counter - 1}])
   end
 
   # totp creation


### PR DESCRIPTION
This function never returned true because it incorrectly compares the boolean returned from `:pot.valid_hotp` with the provided counter:

```elixir
@spec valid_hotp(token(), secret()) :: boolean()
```